### PR TITLE
New ID picking system, default wait time changed, and syntax improvement (v2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Fuck Every ROBLOX Username
-Python script where it tweets every minute fuck along with a random ROBLOX username between the IDs 10.000.000-1.000.000.000 obtained from ROBLOX's API for 2.000.160 times.
-Started in November 14th, 2020 and ends in September 3rd, 2024.
+Python script where it tweets every 5 minutes fuck along with a random ROBLOX username. 
+Username is picked in eras; the eras are: 2004-2007, 2008-2009, 2010-2012, 2013-2015, and 2016-2020.
+If the last era is picked, it'll picked an ID between the first registered 2016 ID and the latest 2020 ID (which is obtained via the RecentRobloxUsers.py script, and is refreshed every 24 hours to avoid sending Roblox a lot of requests.)
  
 ## To set it up:
 Before setting it up, you will need to have a Twitter Developer account. You can do it via https://developer.twitter.com/. If you plan to host the bot on a Twitter account that isn't yours, I'd recommend you to apply for a Developer account IN your main account, later in the guide I'll explain how to set up the bot in another account. 
@@ -20,7 +21,9 @@ If it gives you an error saying that Python wasn't found, replace "python3" with
 
 **5.** Before executing the Python script, you need to put your Twitter API keys on it. To do so, open config_barebones.cfg, and put in your API keys. (Note: if you're going to host the bot on another Twitter account, leave the token_access and secret_token in blank and skip to the next section.). Feel free to tweak the configuration file to your likings. When you're done, change the file name to config.cfg.
 
-**6.** You can now host the bot! To do it, run python3 main.py.
+**6.** You can now run the bot! To do so, you could either run `python3 main.py` or `python3 main.py & python3 RecentRobloxUsers.py` if you want to obtain the last registered ID every 24 hours. 
+
+Keep in mind that if you're running the last command on Linux, when you stop the script RecentRobloxUsers.py will stop but main.py will still be running; a way to stop this is to find its process ID by typing `pgrep python3` then stopping it via `kill [PIDHERE]`. A script will be worked soon to fix this.
 
 ### For users who want to host the bot in another Twitter Account:
 Before doing this I'd like to say that from my experience: **if you're doing this on Windows Subsystem for Linux, you should do this in Windows instead of WSL. I did this in WSL and it didn't release the .twurlrc file for some reason. I probably did something wrong but still, I'd recommend you to do it in Windows instead of WSL.**
@@ -33,18 +36,17 @@ Before doing this I'd like to say that from my experience: **if you're doing thi
 
 **4.** After authenticating, a file called `.twurlrc` will appear; open it. Pay attention to both 'token' and 'secret' keys. Open the config.cfg file that you edited earlier, fill in respectively the 'token' code in 'token_access', and 'secret' code in 'secret_token'. (I know this is logical but some people may don't know about this so I had to mention this.)
 
-**5.** You can now host the bot! To do it, run python3 main.py.
+**5.** You can now run the bot! To do so, you could either run `python3 main.py` or `python3 main.py & python3 RecentRobloxUsers.py` if you want to obtain the last registered ID every 24 hours. 
+
+Keep in mind that if you're running the last command on Linux, when you stop the script RecentRobloxUsers.py will stop but main.py will still be running; a way to stop this is to find its process ID by typing `pgrep python3` then stopping it via `kill [PIDHERE]`. A script will be worked soon to fix this.
 
 ## FAQ
 
-#### Question: Why 2 million usernames and why tweet it every 60 seconds?
-Answer: If i did it every 15 minutes, I would only have 100k usernames in 3/4 years. My goal is to do it with a high quantity of usernames possible that will finish in 3/4 years.
+#### Question: What's with this era thing?
+Answer: It's for relevancy. Think about a bot that picks an username between the first ID and the last ID; there's a problem though, it will never pick the lower IDs. That's where the eras come in, giving both older and newer IDs a chance to be tweeted.
 
-#### Question: Why not pick between the IDs 1 to the last ID?
-Answer: I want to stay relevant; most (if not ALMOST all) relevant usernames are after the ID 10.000.000. If there's demand however, I can change the maximum ID to 2 billion (or the latest one).
-
-#### Question: Isn't 2 million usernames a small quantity?
-Answer: Yeah. If there is enough demand after it reaches 2 million usernames, this bot will still be running until an event happens, like lack of funds to keep the bot up.
+#### Question: Why pick the usernames randomly instead in order?
+Answer: It sounds good, but it would take years (like A LOT of years) to reach modern day usernames.
 
 #### Question: Where is the bot hosted?
 Answer: Amazon Web Services using the instance type t2.micro. I could use an RPi to host it for free but my electricity service's pricing scheme is really weird that if I host it 24/7 on the RPi bills will come really expensive, so I can't.

--- a/RecentRobloxUsers.py
+++ b/RecentRobloxUsers.py
@@ -1,7 +1,6 @@
 import subprocess, sys
 import configparser
 import requests, time, math
-import threading
 from time import sleep
 
 config = configparser.ConfigParser()
@@ -30,7 +29,6 @@ def getUsername(i):
 
 x = 0
 for i in range(30, 0, -1):
-    print(i)
     n = x + pow(2, i)
     if apiRequest(n) or apiRequest(n+1) or apiRequest(n+2):
         x = int(n)
@@ -58,4 +56,4 @@ while True:
     x += 1
 
     sumLastID(x)
-    # sleep(60 * 1440)
+    sleep(60 * 1440)

--- a/RecentRobloxUsers.py
+++ b/RecentRobloxUsers.py
@@ -1,0 +1,61 @@
+import subprocess, sys
+import configparser
+import requests, time, math
+import threading
+from time import sleep
+
+config = configparser.ConfigParser()
+configFile = ('config.cfg')
+config.read(configFile)
+
+def sumLastID(c):
+     config['IDs']['LastID'] = str(c)
+     with open(configFile, 'w') as configfile:
+        config.write(configfile)
+
+def apiRequest(i):  
+    y = r = requests.get("https://api.roblox.com/users/%i" % (i))
+    if '404' in y and r:
+        None
+    if y:
+        return r
+
+def getUsername(i):
+    getAPIrequest = requests.get("https://api.roblox.com/users/%i" % (i)).json()
+    try:
+        user = getAPIrequest['Username']
+        return user
+    except KeyError:
+        return 'Invalid_ID'
+
+x = 0
+for i in range(30, 0, -1):
+    print(i)
+    n = x + pow(2, i)
+    if apiRequest(n) or apiRequest(n+1) or apiRequest(n+2):
+        x = int(n)
+
+timeout = 0
+newest = None
+while True:
+    while True:
+            found = False
+            for i in range(0, math.floor(timeout/10)):
+                q = apiRequest(x + i)
+                if q:
+                    for j in range (0, i-1):
+                        Q = apiRequest(x + j)
+                        if Q:
+                            q = Q
+                            break
+                    found = True
+                    break
+            if found: 
+                break
+            timeout += 1
+    
+    timeout = 0
+    x += 1
+
+    sumLastID(x)
+    # sleep(60 * 1440)

--- a/RecentRobloxUsers.py
+++ b/RecentRobloxUsers.py
@@ -2,10 +2,15 @@ import subprocess, sys
 import configparser
 import requests, time, math
 from time import sleep
+from datetime import datetime
 
 config = configparser.ConfigParser()
 configFile = ('config.cfg')
 config.read(configFile)
+
+def getTime():
+    now = datetime.now()
+    return now.strftime("%d/%m/%y %H:%M:%S")
 
 def sumLastID(c):
      config['IDs']['LastID'] = str(c)
@@ -27,34 +32,39 @@ def getUsername(i):
     except KeyError:
         return 'Invalid_ID'
 
-x = 0
-for i in range(30, 0, -1):
-    n = x + pow(2, i)
-    if apiRequest(n) or apiRequest(n+1) or apiRequest(n+2):
-        x = int(n)
 
-timeout = 0
-newest = None
-while True:
-    while True:
-            found = False
-            for i in range(0, math.floor(timeout/10)):
-                q = apiRequest(x + i)
-                if q:
-                    for j in range (0, i-1):
-                        Q = apiRequest(x + j)
-                        if Q:
-                            q = Q
-                            break
-                    found = True
-                    break
-            if found: 
-                break
-            timeout += 1
-    
+def getLastID():
+    x = 0
+    for i in range(30, 0, -1):
+        n = x + pow(2, i)
+        if apiRequest(n) or apiRequest(n+1) or apiRequest(n+2):
+            x = int(n)
+
     timeout = 0
-    x += 1
+
+    while True:
+        while True:
+                found = False
+                for i in range(0, math.floor(timeout/10)):
+                    q = apiRequest(x + i)
+                    if q:
+                        for j in range (0, i-1):
+                            Q = apiRequest(x + j)
+                            if Q:
+                                q = Q
+                                break
+                        found = True
+                        break
+                if found: 
+                    break
+                timeout += 1
+    
+        timeout = 0
+        x += 1
 
     sumLastID(x)
-    print("New ID: %i" % (x))
+    print("%s - New ID: %i" % (getTime(), x))
+
+while True:
+    getLastID()
     sleep(60 * 1440)

--- a/RecentRobloxUsers.py
+++ b/RecentRobloxUsers.py
@@ -43,24 +43,23 @@ def getLastID():
     timeout = 0
 
     while True:
-        while True:
-                found = False
-                for i in range(0, math.floor(timeout/10)):
-                    q = apiRequest(x + i)
-                    if q:
-                        for j in range (0, i-1):
-                            Q = apiRequest(x + j)
-                            if Q:
-                                q = Q
-                                break
-                        found = True
-                        break
-                if found: 
+            found = False
+            for i in range(0, math.floor(timeout/10)):
+                q = apiRequest(x + i)
+                if q:
+                    for j in range (0, i-1):
+                        Q = apiRequest(x + j)
+                        if Q:
+                            q = Q
+                            break
+                    found = True
                     break
-                timeout += 1
+            if found: 
+                break
+            timeout += 1
     
-        timeout = 0
-        x += 1
+    timeout = 0
+    x += 1
 
     sumLastID(x)
     print("%s - New ID: %i" % (getTime(), x))

--- a/RecentRobloxUsers.py
+++ b/RecentRobloxUsers.py
@@ -56,4 +56,5 @@ while True:
     x += 1
 
     sumLastID(x)
+    print("New ID: %i" % (x))
     sleep(60 * 1440)

--- a/config_barebones.cfg
+++ b/config_barebones.cfg
@@ -5,19 +5,16 @@ token_access =
 secret_token = 
 
 [Count]
-time = 60
+time = 900
 # Changes the time to tweet IN seconds.
 currentcount = 0
 # Users that have been counted
-maximumcount = 2000160
-# Maximum users to count
 
 [Tries]
-# This is used just in case if you got rate-limited on Twitter.
+# This is used just in case if you get rate-limited on Twitter.
 currenttry = 0
 maximumtries = 15 
 
 [IDs]
-minimumid = 1
-maximumid = 141923
-# Feel free to change the maximum ID to anything
+lastid = 1390874933
+# Last ID is the last registered ID. This could be edited by the RecentROBLOXUsers.py script if being run.

--- a/main.py
+++ b/main.py
@@ -121,7 +121,7 @@ while True:
 
     while True:
         try:
-            tweet("fuck %s (ID: %i)" % (username, ID[0])) 
+            tweet("fuck %s (ID: %i; era = %s)" % (username, ID[0], ID[1])) 
             CurrentCount = int(config['Count']['CurrentCount'])
             print(f"{bColors.okGreen}%s - Tweeted: Username = %s, ID = %i, Count = %i, Era = %s{bColors.ENDC}" % (getTime(), username, ID[0], CurrentCount, ID[1]))
             resetCount('Tries', 'CurrentTry') # resets the tries count to avoid problems

--- a/main.py
+++ b/main.py
@@ -53,9 +53,8 @@ def resetLastID():
         config.write(configfile)
 
 def getID():
-    # config.read(configFile)
-    # LastID = int(config['IDs']['LastID'])
-    LastID = id
+    config.read(configFile)
+    LastID = int(config['IDs']['LastID'])
     if LastID < 1390874933:
         resetLastID()
         config.read(configFile) 

--- a/main.py
+++ b/main.py
@@ -122,6 +122,7 @@ while True:
     while True:
         try:
             tweet("fuck %s (ID: %i; era = %s)" % (username, ID[0], ID[1])) 
+            sumCount(CurrentCount, 'Count', 'CurrentCount')
             CurrentCount = int(config['Count']['CurrentCount'])
             print(f"{bColors.okGreen}%s - Tweeted: Username = %s, ID = %i, Count = %i, Era = %s{bColors.ENDC}" % (getTime(), username, ID[0], CurrentCount, ID[1]))
             resetCount('Tries', 'CurrentTry') # resets the tries count to avoid problems

--- a/main.py
+++ b/main.py
@@ -130,7 +130,7 @@ while True:
             break
         except tweepy.TweepError as TweepError:    
             if CurrentTry > MaximumTries or CurrentTry == MaximumTries:
-                print(f"{bColors.fail}%s - Cannot tweet anymore. Trying again in 15 minutes{bColors.ENDC}" % (getTime))
+                print(f"{bColors.fail}%s - Cannot tweet anymore. Trying again in 15 minutes{bColors.ENDC}" % (getTime()))
                 sleep(60 * 15) 
                 break
             else:


### PR DESCRIPTION
FERUN will no longer have a goal; instead it will be infinite.
First, it will pick an era (like 2004-2007), then obtain an ID from that era and tweet the username that matches an ID that matches the picked era.
If the '2016-2020' era is picked, it'll generate an ID between the first registered 2016 ID and the last ID registered (that can be obtained via RecentRobloxUsers.py).
If RecentRobloxUsers.py is not being run, it could use the default last ID that is found in config_barebones.cfg

Due to this, maximum count, minimum and maximum ID has been removed from the config.cfg file.

Default wait time has been changed to 5 minutes.